### PR TITLE
Fix urls for sql2016-clrtypes

### DIFF
--- a/sql2016-clrtypes/sql2016-clrtypes.nuspec
+++ b/sql2016-clrtypes/sql2016-clrtypes.nuspec
@@ -6,8 +6,8 @@
     <title>Microsoft System CLR Types for SQL Server 2016</title>
     <authors>Microsoft</authors>
     <owners>pieter.lazzaro, john.bowker</owners>
-    <licenseUrl>https://www.microsoft.com/en-us/download/details.aspx?id=54106</licenseUrl>
-    <projectUrl>https://www.microsoft.com/en-us/download/details.aspx?id=54106</projectUrl>
+    <licenseUrl>https://www.microsoft.com/en-us/download/details.aspx?id=52676</licenseUrl>
+    <projectUrl>https://www.microsoft.com/en-us/download/details.aspx?id=52676</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>The SQL Server System CLR Types package contains the components implementing the new geometry, geography, and hierarchyid types in SQL Server 2016. This component can be installed separately from the server to allow client applications to use these types outside of the server.</description>
     <summary>The SQL Server 2016 System CLR Types package.</summary>

--- a/sql2016-clrtypes/tools/chocolateyinstall.ps1
+++ b/sql2016-clrtypes/tools/chocolateyinstall.ps1
@@ -4,8 +4,8 @@ $ErrorActionPreference = 'Stop';
 
 $packageName= 'sql2016-clrtypes'
 $toolsDir   = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
-$url        = 'http://download.microsoft.com/download/E/4/1/E41A6614-9FB0-4675-8A97-08F8B1A1827D/EN/SQL13/x86/SQLSysClrTypes.msi'
-$url64      = 'http://download.microsoft.com/download/E/4/1/E41A6614-9FB0-4675-8A97-08F8B1A1827D/EN/SQL13/amd64/SQLSysClrTypes.msi'
+$url        = 'https://download.microsoft.com/download/8/7/2/872BCECA-C849-4B40-8EBE-21D48CDF1456/ENU/x86/SQLSysClrTypes.msi'
+$url64      = 'https://download.microsoft.com/download/8/7/2/872BCECA-C849-4B40-8EBE-21D48CDF1456/ENU/x64/SQLSysClrTypes.msi'
 
 $packageArgs = @{
   packageName   = $packageName


### PR DESCRIPTION
Microsoft has changed the URLs for the install packages which has broken the chocolatey install.

The nuspec also included incorrect URLs, so these have been updated too.