### PR TITLE
Update chocolateyinstall.ps1

### DIFF
--- a/sql2016-clrtypes/tools/chocolateyinstall.ps1
+++ b/sql2016-clrtypes/tools/chocolateyinstall.ps1
@@ -24,10 +24,10 @@ $packageArgs = @{
 $IsSystem32Bit = Get-ProcessorBits -Compare 32
 if (!$IsSystem32Bit) {
   Write-Host 'Installing 32bit version with 64bit.'
-  $packageArgs.url64bit = $params.url
+  $packageArgs.url64bit = $url
   Install-ChocolateyPackage @packageArgs
   
-  $packageArgs.url64bit = $params.url64bit
+  $packageArgs.url64bit = $url64
   Install-ChocolateyPackage @packageArgs
 }
 else {


### PR DESCRIPTION
We found that the package only installed the 32bit version on a 64bit system, so we "write-host"ed your $params variable, and found it to be empty. 

We then just pulled in the $url and $url64 from the top (as suggested), and found that this worked.